### PR TITLE
fixed window's newline character handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function moduleify(css, inject) {
   if (inject === 'base64') {
     exp = 'require("' + path.basename(path.dirname(__dirname)) + '").byUrl("' + base64(css) + '")'
   } else if (inject) {
-    exp = "require('browserify-postcss')('" + css.replace(/'/gm, "\\'").replace(/\n/gm, ' ') + "')"
+    exp = "require('browserify-postcss')('" + css.replace(/'/gm, "\\'").replace(/[\r\n]+/gm, ' ') + "')"
   } else {
     exp = JSON.stringify(css)
   }


### PR DESCRIPTION
On windows newline symbols (\r\n) weren't replaced with space symbol;
This PR fixed this issue